### PR TITLE
add config and update endpoints

### DIFF
--- a/dmx-web.js
+++ b/dmx-web.js
@@ -56,6 +56,15 @@ function DMXWeb() {
 		res.sendfile(__dirname + '/index.html')
 	})
 
+	app.get('/config', function(req, res) {
+		var response = {"devices": DMX.devices, "universes": {}}
+		Object.keys(config.universes).forEach(function(key) {
+			response.universes[key] = config.universes[key].devices
+		})
+
+		res.json(response)
+	})
+
 	app.get('/state/:universe', function(req, res) {
 		if(!(req.params.universe in dmx.universes)) {
 			res.status(404).json({"error": "universe not found"})

--- a/dmx-web.js
+++ b/dmx-web.js
@@ -77,6 +77,22 @@ function DMXWeb() {
 		}
 		res.json({"state": u})
 	})
+	
+	app.post('/state/:universe', function(req, res) {
+		if(!(req.params.universe in dmx.universes)) {
+			res.status(404).json({"error": "universe not found"})
+			return
+		}
+
+		dmx.update(req.params.universe, req.body)
+
+		var universe = dmx.universes[req.params.universe]
+		var u = {}
+		for(var i = 0; i < 256; i++) {
+			u[i] = universe.get(i)
+		}
+		res.json({"state": u})
+	})
 
 	app.post('/animation/:universe', function(req, res) {
 		try {


### PR DESCRIPTION
I added some routes to the web api to integrate support for https://github.com/bluemaex/homebridge-dmxuniverse

``/config`` returns a list of all devices and universes
``POST /state/:universe`` allows updating selective parts of a universe (in the same way as the UI does it via websockets

:cow: 😴 