### PR TITLE
added eurolite LED THA-120PC and BriteQ BT-Theatre 60FC

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -96,5 +96,11 @@ module.exports = {
 				]
 			}
 		}
-	}
+	},
+	'eurolite-led-tha-120PC': {
+		channels: ['red', 'green', 'blue', 'white', 'dimmer', 'strobe', 'effect']
+	},
+	'briteq-bt-theatre-60FC': {
+		channels: ['dimmer', 'strobe', 'effect', 'red', 'green', 'blue', 'white']
+	},
 }


### PR DESCRIPTION
This pull requests adds channel configurations for **eurolite LED THA-120PC** and **BriteQ BT-Theatre 60FC** based on their 7-channel-mode.