### PR TITLE
Fix universe buffer for ArtNet

### DIFF
--- a/drivers/artnet.js
+++ b/drivers/artnet.js
@@ -17,7 +17,7 @@ function EnttecODE(device_id, options) {
 	self.sleepTime = 24
 
 	options = options || {}
-	self.universe_id.writeInt16BE(options.universe || 0, 0)
+	self.universe_id.writeUInt8(options.universe || 0, 0)
 	self.host = device_id || '127.0.0.1'
 	self.port = options.port || 6454
 	self.dev = dgram.createSocket('udp4')


### PR DESCRIPTION
This should be a UInt8 buffer, not an Int16. Previously setting a universe in the options did nothing.