### PR TITLE
Resolve config issue of the Enttec Open Usb, part of issue #24

### DIFF
--- a/drivers/enttec-open-usb-dmx.js
+++ b/drivers/enttec-open-usb-dmx.js
@@ -13,8 +13,8 @@ function EnttecOpenUsbDMX(device_id, options) {
 
 	this.dev = new SerialPort(device_id, {
 		'baudRate': 250000,
-		'databits': 8,
-		'stopbits': 2,
+		'dataBits': 8,
+		'stopBits': 2,
 		'parity': 'none'
 	}, function(err) {
 		if(err) {


### PR DESCRIPTION
Names of serialports options are not good to have 2 stop bits.