### PR TITLE
FIX(animation): consider easing options

### DIFF
--- a/anim.js
+++ b/anim.js
@@ -11,7 +11,8 @@ function Anim() {
 Anim.prototype.add = function(to, duration, options) {
 	var options  = options  || {}
 	var duration = duration || resolution
-	options['easing'] = options['easing'] || 'linear'
+	options.easing = options.easing || 'linear';
+	
 	this.fx_stack.push({'to': to, 'duration': duration, 'options': options})
 	return this
 }
@@ -29,36 +30,44 @@ Anim.prototype.stop = function () {
 
 Anim.prototype.run = function(universe, onFinish) {
 	var config = {}
-	var t = 0
-	var d = 0
-	var a
+	var ticks = 0
+	var duration = 0
+	var animationStep
 
 	var fx_stack = this.fx_stack;
 	var ani_setup = function() {
-		a = fx_stack.shift()
-		t = 0
-		d = a.duration
+		animationStep = fx_stack.shift()
+		ticks = 0
+		duration = animationStep.duration
+
 		config = {}
-		for(var k in a.to) {
+		for (var k in animationStep.to) {
 			config[k] = {
 				'start': universe.get(k),
-				'end':   a.to[k]
+				'end':   animationStep.to[k],
+				'options': animationStep.options
 			}
 		}
 	}
 	var ani_step = function() {
-		var new_vals = {}
-		for(var k in config) {
-			new_vals[k] = Math.round(config[k].start + ease['linear'](t, 0, 1, d) * (config[k].end - config[k].start))
+		var newValues = {}
+		for (var k in config) {
+			var entry = config[k]
+			var easing = ease[entry.options.easing]
+			
+			newValues[k] = Math.round(entry.start + easing(ticks, 0, 1, duration) * (entry.end - entry.start))
 		}
-		t = t + resolution
-		universe.update(new_vals)
-		if(t > d) {
-			if(fx_stack.length > 0) {
+		
+		ticks = ticks + resolution
+		universe.update(newValues)
+		if (ticks > duration) {
+			if (fx_stack.length > 0) {
 				ani_setup()
 			} else {
 				clearInterval(iid)
-				if(onFinish) onFinish()
+				if(onFinish) {
+					onFinish()
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Up to now a default easing method 'linear' was used even
if the easing option has been set.

This commit makes sure that the assigned easing option is considered
when animating.

fixes #67 