### PR TITLE
Add return value to `run` method

### DIFF
--- a/anim.js
+++ b/anim.js
@@ -65,6 +65,8 @@ Anim.prototype.run = function(universe, onFinish) {
 
 	ani_setup()
 	var iid = this.interval = setInterval(ani_step, resolution)
+
+	return this
 }
 
 module.exports = Anim


### PR DESCRIPTION
Currently the `run` method has no return value.

It would be helpful if the method would return a reference
to the animation itselves, so that code like this would
be possible:

````javascript
let foo = new DMX.Animation()
   .add(...)
   .run(...);
````